### PR TITLE
fixing zcage list that it shows type KVM

### DIFF
--- a/lib/imageadm.js
+++ b/lib/imageadm.js
@@ -30,7 +30,8 @@ const ZCAGE = {
 	DS: '/zcage',
 	VMS: '/zcage/vms',
 	LXBRAND: '/usr/lib/brand/lx',
-	BHYVEBRAND: '/usr/lib/brand/bhyve'
+	BHYVEBRAND: '/usr/lib/brand/bhyve',
+    KVMBRAND: '/usr/lib/brand/kvm'
 };
 
 function showProgress(received, total) {

--- a/lib/zonelib.js
+++ b/lib/zonelib.js
@@ -107,6 +107,9 @@ function listzones(listOptions, out) {
 				case "bhyve":
 					type = "BHYVE";
 					break;
+				case "kvm":
+					type = "KVM";
+					break;
 				default:
 					type = "OS";
 					break;


### PR DESCRIPTION
type KVM for zones with brand=kvm