### PR TITLE
BUGFIX: Progress was displaying too many digits

### DIFF
--- a/lib/imageadm.js
+++ b/lib/imageadm.js
@@ -36,7 +36,7 @@ const ZCAGE = {
 };
 
 function showProgress(received, total) {
-	var percentage = (received * 100) / total;
+	var percentage = ((received * 100) / total).toFixed(2);
 	process.stdout.write(percentage + "% |  " + received + "  bytes out of " +
 		total + " bytes.\r");
 }


### PR DESCRIPTION
When downloading images, the progress output was displaying far too
many digits. Such as below

     $ zcage pull --image <image-id> --provider=joyent
     Downloading image 63d6e664-3f1f-11e8-aef6-a3120cf8dd9d
     2.2492796192092466% |  3313912  bytes out of 147332149 bytes. 

This commit will fix that, and now display to 2 decimal places.

     $ zcage pull --image <image-id> --provider=joyent
     Downloading image 63d6e664-3f1f-11e8-aef6-a3120cf8dd9d
     2.39% |  3522184  bytes out of 147332149 bytes.